### PR TITLE
Update atom shell in Gruntfile and add global utils

### DIFF
--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 module.exports = function(grunt) {
   grunt.initConfig({
     'download-atom-shell': {
-      version: '0.20.3',
+      version: '0.21.2',
       outputDir: '../atom_shell'
     },
 

--- a/src/browser/utils/global.js
+++ b/src/browser/utils/global.js
@@ -1,0 +1,52 @@
+var app = require('app');
+var fs = require('fs');
+
+var GlobalUtils = (function() {
+
+  var api = {
+    getAppDirPath: function() {
+      return app.getDataPath();
+    },
+    getAppDirFilenames: function() {
+      fs.readdir(api.getAppDirPath(), function(err, filenames) {
+        return err ? err : filenames;
+      });
+    },
+    getAppConfigPath: function() {
+      return api.getAppDirPath() + '/jotz_app_config.json';
+    },
+    createAppConfigFile: function() {
+      api.getAppConfigData(function(err, fileData) {
+        if (err) {
+          // TODO: decide on standard app configuration properties
+          var appConfigs = { testConfig: false };
+          api.writeAppConfigFile(JSON.stringify(appConfigs));
+        } else {
+          return fileData;
+        }
+      });
+    },
+    writeAppConfigFile: function(configJSON) {
+      var opts = { encoding: 'utf8' };
+      fs.appendFile(api.getAppConfigPath(), configJSON, opts, function(err) {
+        if (err) {
+          // TODO: research error handling with Atom Shell
+        }
+        api.createAppConfigFile();
+      });
+    },
+    getAppConfigData: function(cb) {
+      fs.readFile(api.getAppConfigPath(), 'utf8', function(err, fileData) {
+        err ? cb(err) : cb(null, fileData);
+      });
+    },
+    getUserConfigPath: function() {
+      return api.getAppDirPath() + '/jotz_user_config.json';
+    }
+  };
+
+  return api;
+})();
+
+
+module.exports = GlobalUtils;


### PR DESCRIPTION
The global utilities aren't finished, aren't documented, and aren't covered with tests. But, wanted you guys to see where I was going with the data structure -> a json config file for the app and a json config file for the user. Will finish this through to setting up the notebooks directory and helpers around all of the note CRUD, and test cover. Let me know if you want to pair on it, will be working on it all night.
