### PR TITLE
Finish Notebook store create and update note actions

### DIFF
--- a/src/browser/apis/notes_api.js
+++ b/src/browser/apis/notes_api.js
@@ -11,11 +11,8 @@ var NotesAPI = (function() {
         noteFilenames.indexOf(filename) >= 0 ? cb(true) : cb(false);
       });
     },
-    noteFilename: function(noteId, noteTitle) {
-      return noteId + '_' + api.titleToFile(noteTitle) + '.json';
-    },
-    titleToFile: function(noteTitle) {
-      return noteTitle.toString().toLowerCase().replace(/\s+/gi, '_');
+    noteFilename: function(noteId) {
+      return noteId + '.json';
     },
     writeNote: function(filename, noteData, cb) {
       var filePath = utils.getNotesDirPath() + filename;
@@ -26,7 +23,7 @@ var NotesAPI = (function() {
   // Public API
   return {
     saveNote: function(note, cb) {
-      var filename = api.noteFilename(note.attributes._id, note.attributes.title);
+      var filename = api.noteFilename(note.attributes._id);
       api.findNote(filename, function() {
           api.writeNote(filename, note.attributes, cb);
       });

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -47,15 +47,17 @@ var JotzBrowser = Backbone.Model.extend({
   },
   handleEvents: function() {
     this.get('mainWindow').on('closed', this.removeWindow.bind(this, 'mainWindow'));
-    ipc.on('save-note', function(e, note) {
-      NotesAPI.saveNote(note, function(result) {
-        e.sender.send('save-note-reply', result);
-      });
-    });
+    ipc.on('save-note', this.saveNote);
   },
   removeWindow: function(windowName) {
     this.set(windowName, null);
+  },
+  saveNote: function(e, note) {
+    NotesAPI.saveNote(note, function(result) {
+      e.sender.send('save-note-reply', result);
+    });
   }
+
 });
 
 module.exports = JotzBrowser;

--- a/src/browser/utils/global.js
+++ b/src/browser/utils/global.js
@@ -2,8 +2,15 @@ var app = require('app');
 var fs = require('fs');
 
 var GlobalUtils = (function() {
+
   // Private
-  var MAX_FOR_HASHING = 1000000;
+  function S4() {
+    return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
+  };
+
+  function guid() {
+    return (S4() + S4() + "-" + S4() + "-" + S4() + "-" + S4() + "-" + S4() + S4() + S4());
+  };
 
   // Public
   var api = {
@@ -25,14 +32,8 @@ var GlobalUtils = (function() {
         }
       });
     },
-    getIndexBelowMaxForKey: function(str) {
-      var hash = 0;
-      for (var i = 0; i < str.length; i++) {
-        hash = (hash<<5) + hash + str.charCodeAt(i);
-        hash = hash & hash;
-        hash = Math.abs(hash);
-      }
-      return hash % MAX_FOR_HASHING;
+    createGuid: function() {
+      return guid();
     }
   };
 


### PR DESCRIPTION
Main changes: 
1. filenames for notes don't include title -- now only use the note id + .json, so that note title updates don't create a new file
2. note _id is now a nice guid-lie string with a better generator and no lame hashing fn
3. collection only needs to call `this.saveNote(payload)` and all implementation handling of create/update is hidden from the collection
4. the collection can handle the response of the create/update with `ipc.on('save-note-reply', action to trigger)`
5. right now, if there is an error, on create/read, client isn't doing anything, and if there is no error, the client is just logging out a success message (no display to user)
