### PR TITLE
Finish destroy note functionality for notebook collection

### DIFF
--- a/src/browser/apis/notes_api.js
+++ b/src/browser/apis/notes_api.js
@@ -31,6 +31,10 @@ var NotesAPI = (function() {
         notes.push(note);
         if (0 === --c) cb(notes);
       });
+    },
+    destroyNoteData: function(filename, cb) {
+      var filepath = utils.getNotesDirPath() + filename;
+      fs.unlink(filepath, cb);
     }
   };
 
@@ -41,6 +45,10 @@ var NotesAPI = (function() {
       api.findNote(filename, function() {
           api.writeNote(filename, note.attributes, cb);
       });
+    },
+    destroyNote: function(noteId, cb) {
+      var filename = api.noteFilename(noteId);
+      api.destroyNoteData(filename, cb);
     },
     fetchNotes: function(cb) {
       utils.getNotesDirData(function(filenames) {

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -49,6 +49,7 @@ var JotzBrowser = Backbone.Model.extend({
     this.get('mainWindow').on('closed', this.removeWindow.bind(this, 'mainWindow'));
     ipc.on('save-note', this.saveNote);
     ipc.on('fetch-notes', this.fetchNotes);
+    ipc.on('destroy-note', this.destroyNote);
   },
   removeWindow: function(windowName) {
     this.set(windowName, null);
@@ -62,8 +63,12 @@ var JotzBrowser = Backbone.Model.extend({
     NotesAPI.fetchNotes(function(notes) {
       e.sender.send('fetch-notes-reply', notes);
     });
+  },
+  destroyNote: function(e, noteId) {
+    NotesAPI.destroyNote(noteId, function(err) {
+      e.sender.send('destroy-note-reply', err);
+    });
   }
-
 });
 
 module.exports = JotzBrowser;

--- a/src/browser/utils/global.js
+++ b/src/browser/utils/global.js
@@ -9,7 +9,7 @@ var GlobalUtils = (function() {
   };
 
   function guid() {
-    return (S4() + S4() + "-" + S4() + "-" + S4() + "-" + S4() + "-" + S4() + S4() + S4());
+    return (S4() + S4() + "_" + S4() + "_" + S4() + "_" + S4() + "_" + S4() + S4() + S4());
   };
 
   // Public

--- a/src/renderer/stores/Notebook.js
+++ b/src/renderer/stores/Notebook.js
@@ -14,6 +14,7 @@ var Notebook = Backbone.Collection.extend({
   initialize: function() {
     this.dispatchToken = JotzDispatcher.register(this.dispatchCallback.bind(this));
     ipc.on('save-note-reply', this.handleSaveNoteReply.bind(this));
+    ipc.on('destroy-note-reply', this.handleDestroyNoteReply.bind(this));
     ipc.on('fetch-notes-reply', this.handleFetchNotesReply.bind(this));
   },
 
@@ -25,6 +26,8 @@ var Notebook = Backbone.Collection.extend({
       case 'save-note':
         this.saveNote(payload);
         break;
+      case 'destroy-note':
+        this.destroyNote(payload);
       case 'fetch-notes':
         this.fetchNotes();
       default:
@@ -36,6 +39,10 @@ var Notebook = Backbone.Collection.extend({
     var note = this.set(this.prepareNoteData(payload), { remove: false });
     if (!note.get('_id')) note.set('_id', utils.createGuid());
     ipc.send('save-note', note);
+  },
+
+  destroyNote: function(payload) {
+    ipc.send('destroy-note', payload.content._id);
   },
 
   fetchNotes: function() {
@@ -62,6 +69,16 @@ var Notebook = Backbone.Collection.extend({
     } else {
       // display 'note saved!' message to user
       console.log('note saved successfully');
+    }
+  },
+
+  handleDestroyNoteReply: function(err) {
+    if (err) {
+      // TODO: display note-deletion failure message to user
+      console.log('note deletion unsuccessful -- no note with that Id');
+    } else {
+      // display 'note deleted!' to user and change views
+      console.log('note deleted successfully');
     }
   },
 


### PR DESCRIPTION
1. dispatch from renderer with an obj. like this:  `{ actionType: 'destroy-note', content: { _id: '1123ffcc-b65e-56c3-cbf6-ff92f4d88b1f' } }`
2. all of the rest of the implementation is hidden from the collection
3. the collection can catch the reply of the operation from the browser with `ipc.on('destroy-note-reply'...)`
4. right now, just logging delete success/failure message on reply, need to display to user and or switch views

Cheers
