### PR TITLE
Note save fix

### DIFF
--- a/src/browser/apis/notes_api.js
+++ b/src/browser/apis/notes_api.js
@@ -17,20 +17,22 @@ var NotesAPI = (function() {
     },
     writeNote: function(filename, noteData, cb) {
       var filePath = utils.getNotesDirPath() + filename;
-      fs.writeFile(filePath, JSON.stringify(noteData), { encoding: 'utf8' }, cb);
+      jsf.writeFile(filePath, noteData, cb);
     },
     getNotesData: function(filenames, cb) {
-      var notes = [], c = 0;
+      var notes = [], c = filenames.length;
       filenames.forEach(function(filename) {
-        c++;
+        c--;
         var filepath = utils.getNotesDirPath() + filename;
         api.getNoteData(notes, filepath, cb, c);
       });
     },
     getNoteData: function(notes, filepath, cb, c) {
-      fs.readFile(filepath, { encoding: 'utf8' }, function(err, note) {
-        notes.push(note);
-        if (0 === --c) cb(notes);
+      jsf.readFile(filepath, function(err, note) {
+        if (note) {
+          notes.push(note);
+          if (c === 0) cb(notes);
+        }
       });
     },
     destroyNoteData: function(filename, cb) {

--- a/src/browser/apis/notes_api.js
+++ b/src/browser/apis/notes_api.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var jsf = require('jsonfile');
 var ipc = require('ipc');
 var utils = require('../utils/global');
 

--- a/src/package.json
+++ b/src/package.json
@@ -29,6 +29,7 @@
     "node-jsx": "^0.12.4",
     "react": "^0.12.2",
     "react-tools": "^0.12.2",
-    "underscore": "^1.7.0"
+    "underscore": "^1.7.0",
+    "jsonfile": "2.0.0"
   }
 }

--- a/src/renderer/stores/Notebook.js
+++ b/src/renderer/stores/Notebook.js
@@ -82,8 +82,8 @@ var Notebook = Backbone.Collection.extend({
     }
   },
 
-  handleFetchNotesReply: function(JSONnotes) {
-    this.set(JSON.parse(JSONnotes));
+  handleFetchNotesReply: function(notes) {
+    this.set(notes);
   }
 });
 


### PR DESCRIPTION
1. no stringifying/parsing/trying/catching -- using a very popular package to handle this (jsonfile -- 1million+ downloads past month)
2. the fetch notes now returns a clean javascript array of notes, which the collection sets, which updates the react components (click add note and watch. then reboot and they should load in)
3. added a dependency, so delete atom_shell and node_modules, and follow the usual scratch build process
