### PR TITLE
Block dropdown bugfix

### DIFF
--- a/src/renderer/components/content/editor/BlockMenu.js
+++ b/src/renderer/components/content/editor/BlockMenu.js
@@ -8,7 +8,7 @@ var React = require('react');
 var BlockMenu = React.createClass({
   render: function(){
     return (
-      <select defaultValue="text" onChange={this.props.changeLanguage}>
+      <select defaultValue={this.props.language || "plain_text"} onChange={this.props.changeLanguage}>
         <option value="plain_text">Text</option>
         <option value="javascript">JavaScript</option>
         <option value="coffee">CoffeeScript</option>

--- a/src/renderer/components/content/editor/BlockMenu.js
+++ b/src/renderer/components/content/editor/BlockMenu.js
@@ -6,7 +6,7 @@ var React = require('react');
  */
 
 var BlockMenu = React.createClass({
-  render: function(){
+  render: function() {
     return (
       <select defaultValue={this.props.language || "plain_text"} onChange={this.props.changeLanguage}>
         <option value="plain_text">Text</option>

--- a/src/renderer/components/content/editor/NoteBlock.js
+++ b/src/renderer/components/content/editor/NoteBlock.js
@@ -34,7 +34,7 @@ var NoteBlock = React.createClass({
   render: function () {
     return (
       <div>
-        <BlockMenu changeLanguage={this.changeLanguage} />
+        <BlockMenu language={this.props.language} changeLanguage={this.changeLanguage} />
         <div
           id={'ace-editor' + this.props.blockIndex}
           className='ace-editor-inner'

--- a/src/renderer/components/content/editor/NoteBlock.js
+++ b/src/renderer/components/content/editor/NoteBlock.js
@@ -17,7 +17,7 @@ var NoteBlock = React.createClass({
     this.props.updateBlock(this.props.blockIndex, text, this.props.language);
   },
 
-  changeLanguage: function (event) {
+  changeLanguage: function(event) {
     this.editor.changeLanguage('ace/mode/' + event.target.value);
     this.props.updateBlock(this.props.blockIndex, this.props.text, event.target.value);
   },
@@ -31,7 +31,7 @@ var NoteBlock = React.createClass({
     this.editor.onChange(this.updateNote);
   },
 
-  render: function () {
+  render: function() {
     return (
       <div>
         <BlockMenu language={this.props.language} changeLanguage={this.changeLanguage} />


### PR DESCRIPTION
Fixes block menu component to now display the correct language for each block.

Passing the block's language in as a prop to the block menu that the block creates for itself on render.
