### PR TITLE
Refactor editor to use dispatcher for Note store manipulation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div class="app-container">
-      <div id="sidemenu" class="side-container"></div>
+      <div id="side-menu" class="side-container"></div>
       <div class="right-container">
         <div id="topbar" class="top-container"></div>
         <div id="content" class="content-container"></div>

--- a/src/renderer/actions/action_creator.js
+++ b/src/renderer/actions/action_creator.js
@@ -7,14 +7,25 @@ var actionCreator = {
       content: content
     });
   },
-  newNote: function() {
+  createNote: function() {
     JotzDispatcher.dispatch({
-      actionType: 'new-note'
+      actionType: 'create-note'
     });
   },
   fetchNotes: function() {
     JotzDispatcher.dispatch({
       actionType: 'fetch-notes'
+    });
+  },
+  createBlock: function() {
+    JotzDispatcher.dispatch({
+      actionType: 'create-block'
+    });
+  },
+  updateBlock: function(content) {
+    JotzDispatcher.dispatch({
+      actionType: 'update-block',
+      content: content
     });
   },
   saveNotebook: function(content) {

--- a/src/renderer/components/content/content.js
+++ b/src/renderer/components/content/content.js
@@ -12,7 +12,7 @@ var Content = React.createClass({
 
   //Checks view state, returns jsx for rendering
   renderContent: function() {
-    if(this.props.view === 'Notes') {
+    if (this.props.view === 'Notes') {
       return (
         <NotesList
           notes={this.props.notes}

--- a/src/renderer/components/content/content.js
+++ b/src/renderer/components/content/content.js
@@ -23,7 +23,6 @@ var Content = React.createClass({
       return (
         <Editor
           note={this.props.currentNote}
-          notes={this.props.notes}
           swapView={this.props.swapView}
         />
       );

--- a/src/renderer/components/content/content.js
+++ b/src/renderer/components/content/content.js
@@ -15,15 +15,15 @@ var Content = React.createClass({
     if(this.props.view === 'Notes') {
       return (
         <NotesList
-          allNotes={this.props.allNotes}
+          notes={this.props.notes}
           swapView={this.props.swapView}
         />
       );
     } else if (this.props.view === 'Editor') {
       return (
         <Editor
-          note={this.props.currentNote.clone()}
-          allNotes={this.props.allNotes}
+          note={this.props.currentNote}
+          notes={this.props.notes}
           swapView={this.props.swapView}
         />
       );

--- a/src/renderer/components/content/editor/editor.js
+++ b/src/renderer/components/content/editor/editor.js
@@ -17,7 +17,7 @@ var Editor = React.createClass({
   //Everything is Asynchronous, and using replaceState will wipe all blocks, deleting the note
 
   componentDidMount: function() {
-    this.props.note.on('change:blocks', function() {
+    this.props.note.on('block-updated', function() {
       this.forceUpdate();
     }.bind(this), this);
   },
@@ -26,27 +26,16 @@ var Editor = React.createClass({
     this.props.note.off(null, null, this);
   },
 
-  newBlock: function() {
-    var block = [
-      {
-        language: 'text',
-        content: ''
-      }
-    ];
-
-    var blocks = this.props.note.get('blocks').concat(block);
-    this.props.note.set('blocks', blocks);
+  createBlock: function() {
+    actionCreator.createBlock();
   },
 
-  updateBlock: function(index, value, language) {
-    var content = {
-      language: language,
-      content: value
-    };
-
-    var blocks = this.props.note.get('blocks');
-    blocks[index] = content;
-    this.props.note.set('blocks', blocks);
+  updateBlock: function(index, content, language) {
+    actionCreator.updateBlock({
+      index: index,
+      content: content,
+      language: language
+    })
   },
 
   //flux activity here, props is sent (not changed)
@@ -78,7 +67,7 @@ var Editor = React.createClass({
     return (
       <div className='ace-editor-container'>
         <h3>{this.props.note.get('title')}</h3>
-        <button onClick={this.newBlock}>NEW BLOCK</button>
+        <button onClick={this.createBlock}>NEW BLOCK</button>
         {this.renderBlocks()}
         <button onClick={this.saveNote}>SAVE</button>
         <button onClick={this.closeEditor}>CLOSE EDITOR</button>

--- a/src/renderer/components/content/note_browser/notes_list.js
+++ b/src/renderer/components/content/note_browser/notes_list.js
@@ -8,13 +8,14 @@ var NotesList = React.createClass({
   handleClick: function(e) {
     e.preventDefault();
     var noteId = e.target.attributes.getNamedItem('data-note').value;
-    var note = this.props.allNotes.findWhere({ _id: noteId });
+    var note = this.props.notes.findWhere({ _id: noteId });
     this.props.swapView('Editor', note);
   },
 
   render: function() {
-    var notes = this.props.allNotes.sortBy('_id').map(function(note) {
-      return <li onClick={this.handleClick} data-note={note.get('_id')} key={note.get('_id')}>{note.get('title')}</li>;
+    var notes = this.props.notes.sortBy('_id').map(function(note) {
+      var noteId = note.get('_id');
+      return <li onClick={this.handleClick} data-note={noteId} key={noteId}>{note.get('title')}</li>;
     }.bind(this));
     return (
       <div>

--- a/src/renderer/components/jotz.js
+++ b/src/renderer/components/jotz.js
@@ -2,7 +2,6 @@ var React = require('react/addons');
 var SideMenu = require('./side_menu/side_menu');
 var Content = require('./content/content');
 var TopBar = require('./top_bar/top_bar');
-var NotesStore = require('../stores/notes');
 var actionCreator = require('../actions/action_creator');
 
 /*
@@ -18,22 +17,19 @@ var Jotz = React.createClass({
     actionCreator.fetchNotes();
     actionCreator.fetchNotebooks();
     return {
-      jotzState: {
-        view: 'Notes',
-        allNotes: NotesStore,
-        currentNote: null
-      }
+      view: 'Notes',
+      currentNote: null
     };
   },
 
   componentDidMount: function() {
-    NotesStore.on('all', function(result) {
-      this.updateNotesList();
+    this.props.notes.on('all', function() {
+      this.forceUpdate();
     }.bind(this), this);
   },
 
   componentWillUnmount: function() {
-    NotesStore.off(null, null, this);
+    this.props.notes.off(null, null, this);
   },
 
   /*
@@ -41,46 +37,29 @@ var Jotz = React.createClass({
     as helper functions to change application state.
    */
 
-  updateNotesList: function() {
-    var newState = React.addons.update(this.state, {
-      jotzState: {
-        allNotes: {
-          $set: NotesStore
-        }
-      }
-    });
-    this.setState(newState);
-  },
-
   swapView: function(newView, note) {
     note = note || null;
-    var newState = React.addons.update(this.state, {
-      jotzState: {
-        view: { $set: newView },
-        currentNote: { $set: note }
-      }
+    this.setState({
+      view: newView,
+      currentNote: note
     });
-    this.setState(newState);
   },
 
   //children will access states/data that are passed to them as props
   //never change props, clone and modify instead
   //pass callbacks that change state as props to children
   render: function() {
-    var right = 'right-container';
-    var left = 'side-container';
-
     return (
       <div>
-        <div className={left}>
+        <div className='side-container'>
           <SideMenu swapView={this.swapView}/>
         </div>
-        <div className={right}>
+        <div className='right-container'>
           <TopBar swapView={this.swapView}/>
           <Content
-            allNotes={this.state.jotzState.allNotes}
-            view={this.state.jotzState.view}
-            currentNote={this.state.jotzState.currentNote}
+            notes={this.props.notes}
+            view={this.state.view}
+            currentNote={this.state.currentNote}
             swapView={this.swapView}
           />
         </div>

--- a/src/renderer/components/side_menu/side_menu.js
+++ b/src/renderer/components/side_menu/side_menu.js
@@ -53,7 +53,7 @@ var SideMenu = React.createClass({
       return (
         <MenuItem
           active={this.state.activeMenuItemUid === menuItem.uid}
-          key={menuItem.ui}
+          key={menuItem.uid}
           onSelect={this.setActiveMenuItem}
           uid={menuItem.uid}
           icon={menuItem.icon}
@@ -62,11 +62,11 @@ var SideMenu = React.createClass({
     }.bind(this));
 
     var classes = {
-      sidemenu: 'sidemenu',
+      sideMenu: 'side-menu',
       notebooksLink: 'notebooks-link'
     };
     return (
-      <div className={classes.sidemenu}>
+      <div className={classes.sideMenu}>
         <h1 className='logo'>Jotz</h1>
         <ul className='main-nav'>
           {menuItems}

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,11 +1,14 @@
 var React = require('react');
-
-require('node-jsx').install();
+var Notes = require('./stores/notes');
+var Notebooks = require('./stores/notebooks');
 
 var Jotz = require('./components/jotz');
 
 module.exports = {
   init: function() {
-    React.render(<Jotz />, document.body);
+    React.render(<Jotz
+      notes={Notes}
+      notebooks={Notebooks}
+    />, document.body);
   }
 };

--- a/src/renderer/stores/note.js
+++ b/src/renderer/stores/note.js
@@ -1,7 +1,5 @@
 var Backbone = require('backbone');
-var remote = require('remote');
-var path = require('path');
-var utils = remote.require(path.join(__dirname, '../../browser/utils/global.js'));
+var JotzDispatcher = require('../dispatcher/jotz_dispatcher');
 
 var Note = Backbone.Model.extend({
 
@@ -15,6 +13,44 @@ var Note = Backbone.Model.extend({
       notebookTitle: ''
     }
   },
+
+  initialize: function() {
+    this.dispatchToken = JotzDispatcher.register(this.dispatchCallback.bind(this));
+  },
+
+  dispatchCallback: function(payload) {
+    switch(payload.actionType) {
+      case 'create-block':
+        this.createBlock();
+        break;
+      case 'update-block':
+        this.updateBlock(payload);
+        break;
+      default:
+        break;
+    }
+  },
+
+  createBlock: function() {
+    var blocks = this.get('blocks');
+    blocks.push({
+      language: 'text',
+      content: ''
+    });
+    this.set('blocks', blocks);
+    this.trigger('block-updated');
+  },
+
+  updateBlock: function(payload) {
+    var i = payload.content.index;
+    var blocks = this.get('blocks');
+    blocks[i] = {
+      language: payload.content.language,
+      content: payload.content.content || ''
+    };
+    this.set('blocks', blocks);
+    this.trigger('block-updated');
+  }
 });
 
 module.exports = Note;


### PR DESCRIPTION
Changes:
- Make Notes and Notebooks available throughout the app as props rather than state variables
- Move createBlock & updateBlock functionality out of React component and into Backbone Note model
- Minor naming fixes in methods and classNames

Build instructions:
- Delete atom_shell & src/node_modules
- cd src && apm install .
- grunt build --scratch
