### PR TITLE
Finish backend for check-for-save functionality

### DIFF
--- a/src/browser/apis/notes_api.js
+++ b/src/browser/apis/notes_api.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var jsf = require('jsonfile');
 var ipc = require('ipc');
+var dialog = require('dialog');
 var utils = require('../utils/global');
 
 var NotesAPI = (function() {
@@ -44,6 +45,13 @@ var NotesAPI = (function() {
     destroyNoteData: function(filename, cb) {
       var filepath = utils.getNotesDirPath() + filename;
       fs.unlink(filepath, cb);
+    },
+    savePrompt: function() {
+      return {
+        type: 'info',
+        buttons: ['Save Changes', 'Discard Changes'],
+        message: 'Would you like to save your recent changes before closing this note?'
+      };
     }
   };
 

--- a/src/browser/apis/notes_api.js
+++ b/src/browser/apis/notes_api.js
@@ -74,7 +74,8 @@ var NotesAPI = (function() {
       });
     },
     shouldSave: function(cb) {
-      dialog.showMessageBox(api.savePrompt(), cb);
+      var result = dialog.showMessageBox(api.savePrompt());
+      cb(result);
     }
   };
 

--- a/src/browser/apis/notes_api.js
+++ b/src/browser/apis/notes_api.js
@@ -72,6 +72,9 @@ var NotesAPI = (function() {
       utils.getNotesDirData(function(filenames) {
         api.getNotesData(filenames, cb);
       });
+    },
+    shouldSave: function(cb) {
+      dialog.showMessageBox(api.savePrompt(), cb);
     }
   };
 

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -27,7 +27,9 @@ var JotzBrowser = Backbone.Model.extend({
       'setConfigs',
       'startMainWindow',
       'handleEvents',
-      'removeWindow'
+      'removeWindow',
+      'shouldSave',
+      'sendCheckSaveReply'
     );
   },
   initialize: function() {

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -58,6 +58,7 @@ var JotzBrowser = Backbone.Model.extend({
     ipc.on('destroy-note', this.destroyNote);
     ipc.on('save-notebook', this.saveNotebook);
     ipc.on('fetch-notebooks', this.fetchNotebooks);
+    ipc.on('check-for-save', this.shouldSave);
   },
   removeWindow: function(windowName) {
     this.set(windowName, null);

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -87,6 +87,18 @@ var JotzBrowser = Backbone.Model.extend({
     NotebooksAPI.fetchNotebooks(function(notebooks) {
       e.sender.send('fetch-notebooks-reply', notebooks);
     });
+  },
+  shouldSave: function(e) {
+    NotesAPI.shouldSave(function(result) {
+      this.sendCheckSaveReply(result, e);
+    }.bind(this));
+  },
+  sendCheckSaveReply: function(result, e) {
+    if (result === 1) {
+      e.sender.send('check-for-save-reply', false);
+    } else {
+      e.sender.send('check-for-save-reply', true);
+    }
   }
 });
 


### PR DESCRIPTION
1. 'check-for-save' should be sent via `ipc.send('check-for-save')` from the renderer side (notes/note store)
2. notes/note store should listen for `ipc.on('check-for-save-reply')` which will send `true` for save and `false` for discard
