### PR TITLE
Fix grunt-download-atom-shell not properly unzipping binaries bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ node_modules
 
 # Atom shell
 atom_shell
+atom_cache
 
 # Webstorm
 .idea

--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -9,7 +9,9 @@ module.exports = function(grunt) {
   grunt.initConfig({
     'download-atom-shell': {
       version: '0.21.2',
-      outputDir: '../atom_shell'
+      outputDir: '../atom_shell',
+      downloadDir: '../atom_cache',
+      rebuild: true
     },
 
     pkg: grunt.file.readJSON('package.json'),


### PR DESCRIPTION
Minor bug where grunt-download-atom-shell was not properly installing atom-shell.

Rebuild from scratch, you will have a new atom_cache folder. You don't need to touch that when rebuilding from scratch in the future (it will use the cached version instead of re-downloading). 
