### PR TITLE
Finish jotz browser makeGist and skeleton for handling oauth completion

### DIFF
--- a/src/browser/apis/auth_api.js
+++ b/src/browser/apis/auth_api.js
@@ -1,20 +1,82 @@
 var fs = require('fs');
 var jsf = require('jsonfile');
 var ipc = require('ipc');
+var BrowserWindow = require('browser-window');
 var dialog = require('dialog');
+var _ = require('underscore');
+var Backbone = require('backbone');
 var utils = require('../utils/global');
 
+
 var AuthAPI = (function() {
-
-  // Private API
-  var api = {
-
+  var wConfig = {
+    show: false,
+    "zoom-factor": 0.9,
+    center: true,
+    "always-on-top": true,
+    title: "Log in to Jotz with your GitHub Account"
   };
 
-  // Public API
-  return {
-    authenticate: function() {
+  var OAuthWindow = Backbone.Model.extend({
+    initialize: function(options) {
+      this.set('jotzBrowser', options.jotzBrowser);
+      this.set('configs', wConfig);
+      this.set('authEndpoint', 'http://localhost:8000/api/auth/ghlogin/');
+      this.set('oAuthCount', 0);
+      this.bindMtds();
+    },
+    bindMtds: function() {
+      _.bindAll(this,
+        'registerEvents',
+        'createWindow',
+        'removeWindow',
+        'display',
+        'runGhOAuth',
+        'incrementOAuthCount',
+        'handleOAuthCompletion'
+      );
+    },
+    registerEvents: function() {
+      var win = this.get('oAuthWindow');
+      win.on('closed', this.removeWindow);
+      win.webContents.on('did-get-redirect-request', this.incrementOAuthCount);
+      win.webContents.on('did-finish-load', this.handleOAuthCompletion);
+    },
+    createWindow: function() {
+      this.set('oAuthWindow', new BrowserWindow(this.get('configs')));
+      this.registerEvents();
+      return this.get('oAuthWindow');
+    },
+    removeWindow: function() {
+      this.trigger('oauth-window-closed');
+      this.set('oAuthWindow', null);
+    },
+    display: function() {
+      var win = this.createWindow();
+      win.loadUrl(this.get('authEndpoint'));
+      win.show();
+    },
+    runGhOAuth: function() {
+      this.display();
+    },
+    incrementOAuthCount: function() {
+      this.set('oAuthCount', this.get('oAuthCount') + 1);
+    },
+    handleOAuthCompletion: function() {
+      if (this.get('oAuthCount') === 2) {
+        this.set('oAuthCount', 0);
+        this.get('oAuthWindow').close();
+      }
+    }
+  });
 
+  // Auth Public API
+  return {
+    oAuthWindow: OAuthWindow,
+    ghAuthenticated: function(cb) {
+      // check user_data.json for githubId and accessToken
+      cb(false);
+      // cb(githubId, accessToken);
     }
   };
 

--- a/src/browser/apis/gist_api.js
+++ b/src/browser/apis/gist_api.js
@@ -3,23 +3,34 @@ var jsf = require('jsonfile');
 var ipc = require('ipc');
 var dialog = require('dialog');
 var utils = require('../utils/global');
+var _ = require('underscore');
+var Backbone = require('backbone');
 var AuthAPI = require('./auth_api');
 
-var GistAPI = (function() {
 
-  // Private API
-  var api = {
-
-  };
-
-  // Public API
-  return {
-    makeGist: function(noteBlock, cb) {
-      //AuthAPI.authenticate();
-      //console.log(noteBlock);
+var GistBrowser = Backbone.Model.extend({
+  initialize: function(options) {
+    this.set('jotzBrowser', options.jotzBrowser);
+    this.bindMtds();
+  },
+  bindMtds: function() {
+    _.bindAll(this, 'makeGist', 'publishGist', 'authSwitch');
+  },
+  makeGist: function(noteBlock) {
+    AuthAPI.ghAuthenticated(this.authSwitch.bind(this, noteBlock));
+  },
+  publishGist: function(noteBlock, githubId, ghAccessToken) {
+    // pub gist via jotz-services
+  },
+  authSwitch: function(noteBlock, githubId, ghAccessToken) {
+    if (ghAccessToken) {
+      this.publishGist(noteBlock, githubId, ghAccessToken);
+    } else {
+      this.get('jotzBrowser').set('noteBlock', noteBlock);
+      this.get('jotzBrowser').get('oAuthWindow').runGhOAuth();
     }
-  };
+  }
+});
 
-})();
 
-module.exports = GistAPI;
+module.exports = GistBrowser;

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -126,7 +126,11 @@ var JotzBrowser = Backbone.Model.extend({
     // write response gh id and access token to user_data.json
     // trigger event with noteblock gh id and accesstoken, listen and publish gist
 
+    // example noteBlock passed all the way through oAuth process
+    console.log(this.get('noteBlock'));
+
     //this.get('gistBrowser').publishGist(noteBlock /* githubId, ghAccessToken */);
+
   }
 });
 

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -110,10 +110,23 @@ var JotzBrowser = Backbone.Model.extend({
     }
   },
   makeGist: function(e, noteBlock) {
-    GistAPI.makeGist(noteBlock, function(result) {
+    this.get('gistBrowser').makeGist(noteBlock);
+  },
+  handleOAuthCompletion: function() {
+    // TODO: START HERE
+    // TODO: -> 1. app side user_data.json 2. jotz-services api
 
-      //e.sender.send('make-gist-reply');
-    });
+    // User is authed and stuff stored in DB
+    // Show loading display progress to user ('saving your settings')
+
+    // fetch githubId and access token
+    // request.get('/api/auth/userdata');
+      // -> endpoint pushes through ghOauth again without showing to user,
+      // should skip and return gh id and access token
+    // write response gh id and access token to user_data.json
+    // trigger event with noteblock gh id and accesstoken, listen and publish gist
+
+    //this.get('gistBrowser').publishGist(noteBlock /* githubId, ghAccessToken */);
   }
 });
 

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -29,11 +29,12 @@ var JotzBrowser = Backbone.Model.extend({
       'setupReporters',
       'setConfigs',
       'startMainWindow',
-      'handleEvents',
+      'registerEvents',
       'removeWindow',
       'shouldSave',
       'sendCheckSaveReply',
-      'makeGist'
+      'makeGist',
+      'handleOAuthCompletion'
     );
   },
   initialize: function() {
@@ -51,12 +52,15 @@ var JotzBrowser = Backbone.Model.extend({
       'min-width': this.get('config').minW,
       show: false
     }));
+    this.set('oAuthWindow', new OAuthWindow({ jotzBrowser: this }));
+    this.set('gistBrowser', new GistBrowser({ jotzBrowser: this }));
     this.get('mainWindow').loadUrl(this.get('config').index);
-    this.handleEvents();
+    this.registerEvents();
     this.get('mainWindow').show();
   },
-  handleEvents: function() {
+  registerEvents: function() {
     this.get('mainWindow').on('closed', this.removeWindow.bind(this, 'mainWindow'));
+    this.get('oAuthWindow').on('oauth-window-closed', this.handleOAuthCompletion);
     ipc.on('save-note', this.saveNote);
     ipc.on('fetch-notes', this.fetchNotes);
     ipc.on('destroy-note', this.destroyNote);

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -7,8 +7,9 @@ var BrowserWindow = require('browser-window');
 var ipc = require('ipc');
 var NotesAPI = require('./apis/notes_api');
 var NotebooksAPI = require('./apis/notebooks_api');
-var GistAPI = require('./apis/gist_api');
-
+var AuthAPI = require('./apis/auth_api');
+var GistBrowser = require('./apis/gist_api');
+var OAuthWindow = AuthAPI.oAuthWindow;
 
 var JotzBrowser = Backbone.Model.extend({
   setupReporters: function() {

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
     </div>
     <script>
       require('react');
-      require('node-jsx').install();		
+      require('node-jsx').install();
       window.jotzApp = require('./renderer/main').init();
     </script>
   </body>

--- a/src/package.json
+++ b/src/package.json
@@ -31,6 +31,7 @@
     "react": "^0.12.2",
     "react-tools": "^0.12.2",
     "underscore": "^1.7.0",
-    "jsonfile": "2.0.0"
+    "jsonfile": "2.0.0",
+    "request": "2.53.0"
   }
 }


### PR DESCRIPTION
DELETE atom shell and node modules, `apm install && build --scratch`

The jotz-services will be done in about 2 hours so don't press the create gist button until I submit a PR for that repo.

Also, no styling, no loading indicator, no caching of auth token, etc. -- I am working on that + the service now. 
