### PR TITLE
Browser and windows configurations split for modularity

### DIFF
--- a/src/browser/apis/auth_api.js
+++ b/src/browser/apis/auth_api.js
@@ -75,8 +75,14 @@ var AuthAPI = (function() {
     oAuthWindow: OAuthWindow,
     ghAuthenticated: function(cb) {
       // check user_data.json for githubId and accessToken
+      //if (githubId && accessToken) {
+      //  cb(githubId, accessToken);
+      //} else {
+      //  cb(false);
+      //}
+
+      // FOR TESTING GH OAUTH FLOW - REMOVE ME
       cb(false);
-      // cb(githubId, accessToken);
     }
   };
 

--- a/src/browser/config/main_window.js
+++ b/src/browser/config/main_window.js
@@ -1,0 +1,10 @@
+var path = require('path');
+
+module.exports = {
+  width: 1024,
+  height: 768,
+  'min-height': 600,
+  'min-width': 800,
+  index: path.join('file://', __dirname, '../../index.html'),
+  show: false
+};

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -30,7 +30,8 @@ var JotzBrowser = Backbone.Model.extend({
       'shouldSave',
       'sendCheckSaveReply',
       'makeGist',
-      'handleOAuthCompletion'
+      'handleOAuthCompletion',
+      'publishGist'
     );
   },
   initialize: function() {
@@ -104,24 +105,28 @@ var JotzBrowser = Backbone.Model.extend({
     this.get('gistBrowser').makeGist(noteBlock);
   },
   handleOAuthCompletion: function() {
-    // TODO: START HERE
-    // TODO: -> 1. app side user_data.json 2. jotz-services api
+    // TODO: 1. app side user_data.json
+    // TODO: 2. jotz-services api
+
+    // 1. fetch githubId and accessToken -> request.get('/api/auth/userdata');
+    // 2. write response githubId and accessToken to user_data.json
 
     // User is authed and stuff stored in DB
     // Show loading display progress to user ('saving your settings')
 
-    // fetch githubId and access token
-    // request.get('/api/auth/userdata');
-      // -> endpoint pushes through ghOauth again without showing to user,
-      // should skip and return gh id and access token
+
     // write response gh id and access token to user_data.json
-    // trigger event with noteblock gh id and accesstoken, listen and publish gist
-
-    // example noteBlock passed all the way through oAuth process
-    console.log(this.get('noteBlock'));
-
-    //this.get('gistBrowser').publishGist(noteBlock /* githubId, ghAccessToken */);
-
+    // set gh id and access token on this model
+    //this.set('githubId', githubId);
+    //this.set('ghAccesstoken', ghAccessToken);
+    // trigger event, listen and publish gist
+    //this.trigger('gh-authenticated');
+  },
+  publishGist: function(e) {
+    //var noteBlock = this.get('noteBlock');
+    //var githubId = this.get('githubId');
+    //var accessToken = this.get('ghAccessToken');
+    //this.get('gistBrowser').publishGist(noteBlock, githubId, accessToken);
   }
 });
 


### PR DESCRIPTION
This is another step in getting the gist pub finished. Added logic comments for finishing the gist code after I finish the service side now. Pulled the configs for the main window into a separate file. All window configs will be stored in their own window file in the browser/config/ directory. No functionality should change for end-user.
