### PR TITLE
Finish auth api for all github authentication

### DIFF
--- a/src/browser/apis/auth_api.js
+++ b/src/browser/apis/auth_api.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var request = require('request');
 var jsf = require('jsonfile');
 var ipc = require('ipc');
 var BrowserWindow = require('browser-window');
@@ -6,6 +7,7 @@ var dialog = require('dialog');
 var _ = require('underscore');
 var Backbone = require('backbone');
 var utils = require('../utils/global');
+var bodyScraper = require('../utils/body_scraper');
 
 
 var AuthAPI = (function() {

--- a/src/browser/apis/auth_api.js
+++ b/src/browser/apis/auth_api.js
@@ -19,44 +19,35 @@ var AuthAPI = (function() {
     title: "Log in to Jotz with your GitHub Account"
   };
 
-  var OAuthWindow = Backbone.Model.extend({
+  var OAuthBrowser = Backbone.Model.extend({
     initialize: function(options) {
       this.set('jotzBrowser', options.jotzBrowser);
       this.set('configs', wConfig);
       this.set('authEndpoint', 'http://localhost:8000/api/auth/ghlogin/');
       this.set('oAuthCount', 0);
       this.bindMtds();
+      this.set('oAuthWindow', null);
+      this.set('oAuthWindow', new BrowserWindow(this.get('configs')));
+      this.registerEvents();
     },
     bindMtds: function() {
       _.bindAll(this,
         'registerEvents',
-        'createWindow',
-        'removeWindow',
         'display',
         'runGhOAuth',
         'incrementOAuthCount',
-        'handleOAuthCompletion'
+        'handleOAuthCompletion',
+        'triggerOAuthSave'
       );
     },
     registerEvents: function() {
-      var win = this.get('oAuthWindow');
-      win.on('closed', this.removeWindow);
-      win.webContents.on('did-get-redirect-request', this.incrementOAuthCount);
-      win.webContents.on('did-finish-load', this.handleOAuthCompletion);
-    },
-    createWindow: function() {
-      this.set('oAuthWindow', new BrowserWindow(this.get('configs')));
-      this.registerEvents();
-      return this.get('oAuthWindow');
-    },
-    removeWindow: function() {
-      this.trigger('oauth-window-closed');
-      this.set('oAuthWindow', null);
+      this.get('oAuthWindow').webContents.on('did-get-redirect-request', this.incrementOAuthCount);
+      this.get('oAuthWindow').webContents.on('did-finish-load', this.handleOAuthCompletion);
+      ipc.on('body-scraped', this.triggerOAuthSave);
     },
     display: function() {
-      var win = this.createWindow();
-      win.loadUrl(this.get('authEndpoint'));
-      win.show();
+      this.get('oAuthWindow').loadUrl(this.get('authEndpoint'));
+      this.get('oAuthWindow').show();
     },
     runGhOAuth: function() {
       this.display();
@@ -66,27 +57,30 @@ var AuthAPI = (function() {
     },
     handleOAuthCompletion: function() {
       if (this.get('oAuthCount') === 2) {
+        this.get('oAuthWindow').hide();
         this.set('oAuthCount', 0);
-        this.get('oAuthWindow').close();
+        this.get('oAuthWindow').webContents.executeJavaScript(bodyScraper.code);
       }
+    },
+    triggerOAuthSave: function(e, body) {
+      this.trigger('oauth-window-closed', body);
+    },
+    ghAuthenticated: function(cb) {
+      utils.getAuthData(function(authData) {
+        if (authData.githubId && authData.ghAccessToken) {
+          cb(authData);
+        } else {
+          cb(false);
+        }
+      });
+    },
+    storeData: function(data) {
+      utils.writeAuthData(data);
     }
   });
 
   // Auth Public API
-  return {
-    oAuthWindow: OAuthWindow,
-    ghAuthenticated: function(cb) {
-      // check user_data.json for githubId and accessToken
-      //if (githubId && accessToken) {
-      //  cb(githubId, accessToken);
-      //} else {
-      //  cb(false);
-      //}
-
-      // FOR TESTING GH OAUTH FLOW - REMOVE ME
-      cb(false);
-    }
-  };
+  return { oAuthBrowser: OAuthBrowser };
 
 })();
 

--- a/src/browser/apis/gist_api.js
+++ b/src/browser/apis/gist_api.js
@@ -5,7 +5,6 @@ var dialog = require('dialog');
 var utils = require('../utils/global');
 var _ = require('underscore');
 var Backbone = require('backbone');
-var AuthAPI = require('./auth_api');
 
 
 var GistBrowser = Backbone.Model.extend({
@@ -17,17 +16,18 @@ var GistBrowser = Backbone.Model.extend({
     _.bindAll(this, 'makeGist', 'publishGist', 'authSwitch');
   },
   makeGist: function(noteBlock) {
-    AuthAPI.ghAuthenticated(this.authSwitch.bind(this, noteBlock));
+    this.get('jotzBrowser').get('oAuthBrowser').ghAuthenticated(this.authSwitch.bind(this, noteBlock));
   },
-  publishGist: function(noteBlock, githubId, ghAccessToken) {
-    // pub gist via jotz-services
+  publishGist: function(noteBlock, authData) {
+    // TODO: publish gist via jotz-services
+    console.log(noteBlock, authData);
   },
-  authSwitch: function(noteBlock, githubId, ghAccessToken) {
-    if (ghAccessToken) {
-      this.publishGist(noteBlock, githubId, ghAccessToken);
+  authSwitch: function(noteBlock, authData) {
+    if (authData) {
+      this.publishGist(noteBlock, authData);
     } else {
       this.get('jotzBrowser').set('noteBlock', noteBlock);
-      this.get('jotzBrowser').get('oAuthWindow').runGhOAuth();
+      this.get('jotzBrowser').get('oAuthBrowser').runGhOAuth();
     }
   }
 });

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -7,9 +7,8 @@ var BrowserWindow = require('browser-window');
 var ipc = require('ipc');
 var NotesAPI = require('./apis/notes_api');
 var NotebooksAPI = require('./apis/notebooks_api');
-var AuthAPI = require('./apis/auth_api');
 var GistBrowser = require('./apis/gist_api');
-var OAuthWindow = AuthAPI.oAuthWindow;
+var OAuthBrowser = require('./apis/auth_api').oAuthBrowser;
 var mainWindowConfigs = require('./config/main_window');
 
 
@@ -43,7 +42,7 @@ var JotzBrowser = Backbone.Model.extend({
   },
   startMainWindow: function() {
     this.set('mainWindow', new BrowserWindow(this.get('mainWindowConfigs')));
-    this.set('oAuthWindow', new OAuthWindow({ jotzBrowser: this }));
+    this.set('oAuthBrowser', new OAuthBrowser({ jotzBrowser: this }));
     this.set('gistBrowser', new GistBrowser({ jotzBrowser: this }));
     this.get('mainWindow').loadUrl(this.get('mainWindowConfigs').index);
     this.registerEvents();
@@ -51,7 +50,7 @@ var JotzBrowser = Backbone.Model.extend({
   },
   registerEvents: function() {
     this.get('mainWindow').on('closed', this.removeWindow.bind(this, 'mainWindow'));
-    this.get('oAuthWindow').on('oauth-window-closed', this.handleOAuthCompletion);
+    this.get('oAuthBrowser').on('oauth-window-closed', this.handleOAuthCompletion);
     this.on('gh-authenticated', this.publishGist);
     ipc.on('save-note', this.saveNote);
     ipc.on('fetch-notes', this.fetchNotes);

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -103,29 +103,20 @@ var JotzBrowser = Backbone.Model.extend({
   makeGist: function(e, noteBlock) {
     this.get('gistBrowser').makeGist(noteBlock);
   },
-  handleOAuthCompletion: function() {
-    // TODO: 1. app side user_data.json
-    // TODO: 2. jotz-services api
-
-    // 1. fetch githubId and accessToken -> request.get('/api/auth/userdata');
-    // 2. write response githubId and accessToken to user_data.json
-
-    // User is authed and stuff stored in DB
-    // Show loading display progress to user ('saving your settings')
-
-
-    // write response gh id and access token to user_data.json
-    // set gh id and access token on this model
-    //this.set('githubId', githubId);
-    //this.set('ghAccesstoken', ghAccessToken);
-    // trigger event, listen and publish gist
-    //this.trigger('gh-authenticated');
+  handleOAuthCompletion: function(body) {
+    // TODO 1. Show loading display progress to user ('saving your settings')
+    var data = JSON.parse(body);
+    var id = data.githubId;
+    var token = data.ghAccessToken;
+    this.set('githubId', id);
+    this.set('ghAccessToken', token);
+    this.get('oAuthBrowser').storeData(data);
+    this.trigger('gh-authenticated', data);
+    // TODO 3. hide loading progress display
+    // TODO 3. show gist publication progress display
   },
-  publishGist: function(e) {
-    //var noteBlock = this.get('noteBlock');
-    //var githubId = this.get('githubId');
-    //var accessToken = this.get('ghAccessToken');
-    //this.get('gistBrowser').publishGist(noteBlock, githubId, accessToken);
+  publishGist: function(authData) {
+    this.get('gistBrowser').publishGist(this.get('noteBlock'), authData);
   }
 });
 

--- a/src/browser/utils/body_scraper.js
+++ b/src/browser/utils/body_scraper.js
@@ -1,0 +1,13 @@
+var scriptCode = "var ipc = require(\"ipc\");" +
+                 "ipc.send(\"body-scraped\", " +
+                 "document.body.innerHTML);";
+var getHead = "var head = document.getElementsByTagName('head')[0];"
+var createScript = "var script = document.createElement('script');";
+var setScriptHTML = "script.innerHTML = '" + scriptCode + "';"
+var appendScript = "head.appendChild(script);";
+var codeString = getHead + createScript + setScriptHTML + appendScript;
+
+
+module.exports = {
+  code: codeString
+};

--- a/src/browser/utils/global.js
+++ b/src/browser/utils/global.js
@@ -18,6 +18,24 @@ var GlobalUtils = (function() {
     getAppDirPath: function() {
       return app.getDataPath();
     },
+    getAuthDataPath: function() {
+      return api.getAppDirPath() + '/auth_data.json';
+    },
+    createAuthDataFile: function(cb) {
+      jsf.writeFile(api.getAuthDataPath(), [], cb);
+    },
+    getAuthData: function(cb) {
+      jsf.readFile(api.getAuthDataPath(), function(err, authData) {
+        if (!err) {
+          cb(authData);
+        } else {
+          api.createAuthDataFile(function() { cb([]); });
+        }
+      });
+    },
+    writeAuthData: function(data) {
+      jsf.writeFile(api.getAuthDataPath(), data);
+    },
     getNotesDirPath: function() {
       return api.getAppDirPath() + '/notes/';
     },


### PR DESCRIPTION
1. Finished all github oauth flow and user permission storage
2. Click 'create gist' and oauth will happen and the note/access token/github id will be logged out after authentication, or authentication will be skipped if token/id are stored in auth_data.json
3. Now, just need to hit our service with the token/id/note and send it along to github
4. Also, need to display progess/loading screens

NOTE: external service isn't pubbed yet, so this won't work for you unless you spin up the external service locally. Working on that now. ALSO: delete atom/nodemods and rebuild scratch
