### PR TITLE
Another Major Step towards a Gist Feature

### DIFF
--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -30,7 +30,8 @@ var JotzBrowser = Backbone.Model.extend({
       'sendCheckSaveReply',
       'makeGist',
       'handleOAuthCompletion',
-      'publishGist'
+      'publishGist',
+      'handleGistUpdateOfNote'
     );
   },
   initialize: function() {
@@ -51,6 +52,7 @@ var JotzBrowser = Backbone.Model.extend({
   registerEvents: function() {
     this.get('mainWindow').on('closed', this.removeWindow.bind(this, 'mainWindow'));
     this.get('oAuthBrowser').on('oauth-window-closed', this.handleOAuthCompletion);
+    this.get('gistBrowser').on('note-updated-by-gist', this.handleGistUpdateOfNote);
     this.on('gh-authenticated', this.publishGist);
     ipc.on('save-note', this.saveNote);
     ipc.on('fetch-notes', this.fetchNotes);

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -102,8 +102,8 @@ var JotzBrowser = Backbone.Model.extend({
       e.sender.send('check-for-save-reply', true, note);
     }
   },
-  makeGist: function(e, noteBlock) {
-    this.get('gistBrowser').makeGist(noteBlock);
+  makeGist: function(e, payload) {
+    this.get('gistBrowser').makeGist(payload);
   },
   handleOAuthCompletion: function(body) {
     // TODO 1. Show loading display progress to user ('saving your settings')

--- a/src/browser/jotz_browser.js
+++ b/src/browser/jotz_browser.js
@@ -118,7 +118,10 @@ var JotzBrowser = Backbone.Model.extend({
     // TODO 3. show gist publication progress display
   },
   publishGist: function(authData) {
-    this.get('gistBrowser').publishGist(this.get('noteBlock'), authData);
+    this.get('gistBrowser').publishGist(this.get('payload'), authData);
+  },
+  handleGistUpdateOfNote: function(updatedNote) {
+    this.get('mainWindow').webContents.send('make-gist-reply', updatedNote.attributes);
   }
 });
 

--- a/src/renderer/components/content/editor/editor.js
+++ b/src/renderer/components/content/editor/editor.js
@@ -68,7 +68,12 @@ var Editor = React.createClass({
   },
 
   makeGist: function(blockIndex) {
-    actionCreator.makeGist(this.state.note.get('blocks')[blockIndex]);
+    var payload = {
+      block: this.state.note.get('blocks')[blockIndex],
+      note: this.state.note,
+      blockIdx: blockIndex
+    };
+    actionCreator.makeGist(payload);
   },
 
   deleteBlock: function(index) {

--- a/src/renderer/stores/notes.js
+++ b/src/renderer/stores/notes.js
@@ -77,6 +77,7 @@ var Notes = Backbone.Collection.extend({
   },
 
   makeGist: function(payload) {
+    this.currentNote = this.add(payload.content.note, { merge: true });
     ipc.send('make-gist', payload.content);
   },
 
@@ -92,7 +93,6 @@ var Notes = Backbone.Collection.extend({
   handleSaveNoteReply: function(err, note) {
     if (err) {
       // TODO: ask guys how we want to handle error
-      // pull it out of collection and add error message to user?
       this.fetchNotes();
     } else {
       this.currentNote.set(note.attributes);
@@ -116,8 +116,18 @@ var Notes = Backbone.Collection.extend({
     }
   },
 
-  handleMakeGistReply: function() {
-
+  handleMakeGistReply: function(updatedNoteAttributes) {
+    if (!updatedNoteAttributes) {
+      this.fetchNotes();
+      // TODO: error handling display to user
+    } else {
+      this.currentNote.set(updatedNoteAttributes);
+      this.fetchNotes();
+      console.log('gist published successfully!');
+      // TODO: remove 'create gist' button
+      // TODO: add 'update gist' button and logic
+      // TODO: add 'copy gist url to share' button and logic
+    }
   }
 });
 


### PR DESCRIPTION
1. each note's noteblocks get a gistUrl and gistId if they have been published -- stored in file and synced with collection

TODOs:
1. remove 'create gist' button for a block that has been published
2. add 'update gist' button for a block that has been published (also write logic/service for updating a gist)
3. add 'copy gist url to share' button and logic
4. refactor
